### PR TITLE
Requirement for Mink-Extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "behat/behat": "2.5.*",
         "illuminate/support": "*",
         "alexandresalome/php-selenium": "1.0.1",
-        "zizaco/testcases-laravel": "dev-master"
+        "zizaco/testcases-laravel": "dev-master",
+        "behat/mink-extension": "1.3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"


### PR DESCRIPTION
When creating a FeatureContext, it will extend MinkContext, but the mink-extension is missing in composer.json
