### PR TITLE
Fix deprecated using of Yaml::parse().

### DIFF
--- a/src/GuilhermeGuitte/BehatLaravel/BehatLaravelServiceProvider.php
+++ b/src/GuilhermeGuitte/BehatLaravel/BehatLaravelServiceProvider.php
@@ -19,8 +19,8 @@ class BehatLaravelServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        
-       
+        $config = Yaml::parse(file_get_contents(base_path() . '/behat.yml'));
+
         $this->app['command.behat.install'] = $this->app->share(function($app)
         {
             return new BehatLaravelCommand();
@@ -28,25 +28,22 @@ class BehatLaravelServiceProvider extends ServiceProvider {
 
         $this->commands('command.behat.install');
 
-        $this->app['command.behat.run'] = $this->app->share(function($app)
+        $this->app['command.behat.run'] = $this->app->share(function($app) use ($config)
         {
-            $config = Yaml::parse('app/../behat.yml');
             return new RunBehatLaravelCommand($config);
         });
 
         $this->commands('command.behat.run');
 
-        $this->app['command.behat.feature'] = $this->app->share(function($app)
+        $this->app['command.behat.feature'] = $this->app->share(function($app) use ($config)
         {
-            $config = Yaml::parse('app/../behat.yml');
             return new FeatureBehatLaravelCommand($config);
         });
 
         $this->commands('command.behat.feature');
 
-        $this->app['command.behat.generate_doc'] = $this->app->share(function($app)
+        $this->app['command.behat.generate_doc'] = $this->app->share(function($app) use ($config)
         {
-            $config = Yaml::parse('app/../behat.yml');
             return new DocumentationCommand($config);
         });
 


### PR DESCRIPTION
The ability to pass file names to Yaml::parse() was deprecated in 2.2 and will be removed in 3.0. Need to pass the contents of the file instead:

https://github.com/symfony/Yaml/blob/master/Yaml.php#L58
